### PR TITLE
Added a partition key

### DIFF
--- a/instructions/dp-200-04_instructions.md
+++ b/instructions/dp-200-04_instructions.md
@@ -541,7 +541,7 @@ The main tasks for this exercise are as follows:
 
         await this.client.CreateDatabaseIfNotExistsAsync(new Database { Id = "Users" });
 
-        await this.client.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri("Users"), new DocumentCollection { Id = "WebCustomers" });
+        await this.client.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri("Users"), new DocumentCollection { Id = "WebCustomers", PartitionKey = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string> { "/userId" }} }); 
 
         Console.WriteLine("Database and collection validation complete");
     }


### PR DESCRIPTION
In line 544, `await this.client.CreateDocumentCollectionIfNotExistsAsync(...)` was called without defining a partition key. This yields errors when you try to add documents later during the demo (line 683/690, where a document is read and created). With the proposed change, the partition key is defined during the creation of the DocumentCollection, so the error won't occurl.