### PR TITLE
Update dp-200-05_instructions.md

### DIFF
--- a/instructions/dp-200-05_instructions.md
+++ b/instructions/dp-200-05_instructions.md
@@ -472,7 +472,7 @@ The main tasks for this exercise are as follows:
 
     ```scala
     //SQL Data Warehouse related settings
-    val dwDatabase = "DBDW"
+    val dwDatabase = "DWDB"
     val dwServer = "sqlservicexx.database.windows.net"
     val dwUser = "xxsqladmin"
     val dwPass = "P@Ssw0rd"


### PR DESCRIPTION
Because of inconsistent DW naming in instruction for writing from Azure Databricks to Azure SQL Data Warehouse, you will run into an error 4060 - "Server rejected the connection; Access to selected database has been denied". 

If you use the correct name it will work.